### PR TITLE
Allows for easier creation of fuzzy list of objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@
 Change Log
 ==========
 
+* :release:`0.1.3 <unreleased>`
+* :feature:`3` updating FuzzyList to allow for a list of objects
 * :release:`0.1.2 <2021-06-26>`
 * :feature:`1` switch core library to rapidfuzz
 * :release:`0.1.1 <2020-04-17>`

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -120,7 +120,8 @@ todo_include_todos = False
 # Intersphinx mappings
 intersphinx_mapping = {'python': ('https://docs.python.org/3.6', None),
                        'astropy': ('http://docs.astropy.org/en/latest', None),
-                       'numpy': ('http://docs.scipy.org/doc/numpy/', None)}
+                       'numpy': ('http://docs.scipy.org/doc/numpy/', None),
+                       'rapidfuzz': ('https://maxbachmann.github.io/RapidFuzz/', None)}
 
 autodoc_mock_imports = ['_tkinter']
 autodoc_member_order = 'groupwise'

--- a/fuzzy_types/configuration.py
+++ b/fuzzy_types/configuration.py
@@ -10,12 +10,13 @@ import inspect
 import os
 import pathlib
 import yaml
+from typing import Union
 
 
 __all__ = ['read_yaml_file', 'merge_config', 'get_config']
 
 
-def read_yaml_file(path):
+def read_yaml_file(path: Union[str, pathlib.Path]) -> dict:
     """Read a YAML file and returns a dictionary."""
 
     if isinstance(path, (str, pathlib.Path)):
@@ -28,7 +29,7 @@ def read_yaml_file(path):
     return config
 
 
-def merge_config(user, default):
+def merge_config(user: dict, default: dict) -> dict:
     """Merges a user configuration with the default one."""
 
     if isinstance(user, dict) and isinstance(default, dict):
@@ -41,8 +42,8 @@ def merge_config(user, default):
     return user
 
 
-def get_config(name, config_file=None, allow_user=True, user_path=None,
-               config_envvar=None, merge_mode='update'):
+def get_config(name: str, config_file: str = None, allow_user: bool = True, 
+               user_path: str = None, config_envvar: str = None, merge_mode: str = 'update') -> dict:
     """Returns a configuration dictionary.
 
     The configuration dictionary is created by merging the default

--- a/fuzzy_types/fuzzy.py
+++ b/fuzzy_types/fuzzy.py
@@ -15,11 +15,12 @@ from __future__ import print_function, division, absolute_import
 from collections import OrderedDict
 
 import abc
+import inspect
 import six
 from fuzzy_types.utils import get_best_fuzzy
 from typing import Callable, Union, TypeVar
 
-__all__ = ['FuzzyList', 'FuzzyDict', 'FuzzyOrderedDict', 'FuzzyStr']
+__all__ = ['FuzzyBase', 'FuzzyBaseDict', 'FuzzyList', 'FuzzyDict', 'FuzzyOrderedDict', 'FuzzyStr']
 
 # types
 FL = TypeVar('FL', bound='FuzzyList')
@@ -116,7 +117,7 @@ class FuzzyBaseDict(FuzzyBase):
 
     @property
     def choices(self) -> list:
-        return [self.mapper(i) for i in self.keys() if isinstance(i, six.string_types)]
+        return [self.mapper(i) for i in self.keys()]
 
 
 class FuzzyDict(FuzzyBaseDict, dict):
@@ -182,7 +183,7 @@ class FuzzyList(FuzzyBase, list):
 
     @property
     def choices(self) -> list:
-        return [self.mapper(item) for item in self if isinstance(item, six.string_types)]
+        return [self.mapper(item) for item in self]
 
     def __getitem__(self, value):
         if not isinstance(value, six.string_types):

--- a/fuzzy_types/fuzzy.py
+++ b/fuzzy_types/fuzzy.py
@@ -17,19 +17,28 @@ from collections import OrderedDict
 import abc
 import six
 from fuzzy_types.utils import get_best_fuzzy
+from typing import Callable, Union, TypeVar
 
 __all__ = ['FuzzyList', 'FuzzyDict', 'FuzzyOrderedDict', 'FuzzyStr']
 
+# types
+FL = TypeVar('FL', bound='FuzzyList')
+FD = TypeVar('FD', bound='FuzzyDict')
+FOD = TypeVar('FOD', bound='FuzzyOrderedDict')
+FS = TypeVar('FS', bound='FuzzyStr')
+AF = Union[FL, FD, FOD, FS]
 
 class FuzzyBase(abc.ABC):
+    """ Abstract Base Class for all Fuzzy objects """
     _base = None
 
-    def __init__(self, the_items, use_fuzzy=None, dottable=True):
+    def __init__(self, the_items: Union[list, dict], use_fuzzy: Callable = None, 
+                 dottable: bool = True):
         self.use_fuzzy = use_fuzzy or get_best_fuzzy
         self._dottable = dottable
         self._base.__init__(self, the_items)
 
-    def __getattr__(self, value):
+    def __getattr__(self, value: Union[str, int, object]):
         if self._dottable is False:
             raise AttributeError(f"'{self._base.__name__}' object has no attribute '{value}'")
 
@@ -42,19 +51,18 @@ class FuzzyBase(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def __dir__(self):
-        members = object.__dir__(self)
-        return members
+    def __dir__(self) -> list:
+        return object.__dir__(self)
 
     @staticmethod
-    def mapper(item):
+    def mapper(item) -> str:
         return str(item)
 
     @abc.abstractproperty
     def choices(self):
         pass
 
-    def __contains__(self, value):
+    def __contains__(self, value: Union[str, int, object]) -> bool:
         if not isinstance(value, six.string_types):
             return super(FuzzyBase, self).__contains__(value)
 
@@ -65,102 +73,115 @@ class FuzzyBase(abc.ABC):
 
         return best in self.choices
 
-    def copy(self):
+    def copy(self) -> AF:
+        """ Returns a copy of the fuzzy instance
+
+        Returns
+        -------
+        Union[list, dict]
+            A copy of the fuzzy instance
+        """
         if self._base == OrderedDict:
             kopied = dict(self)
         else:
             kopied = self._base.copy(self)
         return self.__class__(kopied, use_fuzzy=self.use_fuzzy, dottable=self._dottable)
 
-    def to_original(self):
-        ''' Convert fuzzy object back to original Python datatype '''
+    def to_original(self) -> Union[list, dict]:
+        """ Convert fuzzy object back to original Python datatype """
         return self._base(self)
 
 
 class FuzzyBaseDict(FuzzyBase):
 
-    def __init__(self, the_dict, use_fuzzy=None, dottable=True):
+    def __init__(self, the_dict: dict, use_fuzzy: Callable = None, dottable: bool = True):
         super(FuzzyBaseDict, self).__init__(the_dict, use_fuzzy=use_fuzzy, dottable=dottable)
         # in case a value is another dictionary; also make it fuzzy
         for key, val in the_dict.items():
             if isinstance(val, dict):
                 self[key] = self.__class__(val)
 
-    def __getitem__(self, value):
+    def __getitem__(self, value: Union[int, str]):
         if not isinstance(value, six.string_types):
             return self.get(value)
 
         best = self.use_fuzzy(value, self.choices)
         return self._base.__getitem__(self, best)
 
-    def __dir__(self):
+    def __dir__(self) -> list:
         members = super(FuzzyBaseDict, self).__dir__()
         if self._dottable is True:
             members.extend(self.choices)
         return members
 
     @property
-    def choices(self):
+    def choices(self) -> list:
         return [self.mapper(i) for i in self.keys() if isinstance(i, six.string_types)]
 
 
 class FuzzyDict(FuzzyBaseDict, dict):
-    ''' A dotable dictionary that uses fuzzywuzzy to select the key.
+    """ A dotable dictionary that uses rapidfuzz to select the key.
 
-    Parameters:
-        the_items (dict):
-            A dictionary of items to make fuzzy
-        use_fuzzy (func):
-            The function used to perform the fuzzy-matching.
-            Default is :func:`fuzzy_types.utils.get_best_fuzzy`.
-        dottable (bool):
-            If False, turns off dottable attributes.  Default is True.
+    Parameters
+    ----------
+    the_items : dict
+        A dictionary of items to make fuzzy
+    use_fuzzy : Callable 
+        The function used to perform the fuzzy-matching.
+        Default is :func:`fuzzy_types.utils.get_best_fuzzy`.
+    dottable : bool
+        If False, turns off dottable attributes.  Default is True.
 
-    Returns:
+    Returns
+    -------
         A python dictionary with fuzzy keys
-    '''
+    """
     _base = dict
 
 
 class FuzzyOrderedDict(FuzzyBaseDict, OrderedDict):
-    ''' A dotable ordered dictionary that uses fuzzywuzzy to select the key.
+    """ A dotable ordered dictionary that uses rapidfuzz to select the key.
 
-    Parameters:
-        the_items (dict):
-            A dictionary of items to make fuzzy
-        use_fuzzy (func):
-            The function used to perform the fuzzy-matching.
-            Default is :func:`fuzzy_types.utils.get_best_fuzzy`.
-        dottable (bool):
-            If False, turns off dottable attributes.  Default is True.
+    Parameters
+    ----------
+    the_items : dict
+        A dictionary of items to make fuzzy
+    use_fuzzy : Callable 
+        The function used to perform the fuzzy-matching.
+        Default is :func:`fuzzy_types.utils.get_best_fuzzy`.
+    dottable : bool
+        If False, turns off dottable attributes.  Default is True.
 
-    Returns:
+    Returns
+    -------
         A python ordered dictionary with fuzzy keys
 
-    '''
+    """
     _base = OrderedDict
 
 
 class FuzzyList(FuzzyBase, list):
-    ''' A dottable python list that uses fuzzywuzzy to select a string item
+    """ A dottable python list that uses rapidfuzz to select a string item
 
-    Parameters:
-        the_items (list):
-            A list of items to make fuzzy
-        use_fuzzy (func):
-            The function used to perform the fuzzy-matching.
-            Default is :func:`fuzzy_types.utils.get_best_fuzzy`.
-        dottable (bool):
-            If False, turns off dottable attributes.  Default is True.
+    Parameters
+    ----------
+    the_items : list
+        A list of items to make fuzzy
+    use_fuzzy : Callable 
+        The function used to perform the fuzzy-matching.
+        Default is :func:`fuzzy_types.utils.get_best_fuzzy`.
+    dottable : bool
+        If False, turns off dottable attributes.  Default is True.
 
-    Returns:
+    Returns
+    -------
         A python list with fuzzy items
 
-    '''
+    """
     _base = list
 
     @property
-    def choices(self):
+    def choices(self) -> list:
         return [self.mapper(item) for item in self if isinstance(item, six.string_types)]
 
     def __getitem__(self, value):
@@ -170,7 +191,7 @@ class FuzzyList(FuzzyBase, list):
         best = self.use_fuzzy(value, self.choices)
         return self[self.choices.index(best)]
 
-    def __dir__(self):
+    def __dir__(self) -> list:
         members = super(FuzzyList, self).__dir__()
         if self._dottable is True:
             members.extend(self.choices)
@@ -178,22 +199,23 @@ class FuzzyList(FuzzyBase, list):
 
 
 class FuzzyStr(str):
-    ''' A fuzzy string that uses fuzzywuzzy for equality checks
+    """ A fuzzy string that uses rapidfuzz for equality checks
 
-    Parameters:
-        the_string (str):
-            A string to make fuzzy
-        use_fuzzy (func):
-            The function used to perform the fuzzy-matching.
-            Default is :func:`fuzzy_types.utils.get_best_fuzzy`.
-    '''
+    Parameters
+    ----------
+    the_string : str
+        A string to make fuzzy
+    use_fuzzy : Callable
+        The function used to perform the fuzzy-matching.
+        Default is :func:`fuzzy_types.utils.get_best_fuzzy`.
+    """
     _base = str
 
-    def __init__(self, the_string, use_fuzzy=None):
+    def __init__(self, the_string: str, use_fuzzy: Callable = None):
         self.use_fuzzy = use_fuzzy or get_best_fuzzy
         self._base.__init__(the_string)
 
-    def __eq__(self, value):
+    def __eq__(self, value: str) -> bool:
         try:
             self.use_fuzzy(value, [self])
         except ValueError:

--- a/fuzzy_types/fuzzy.py
+++ b/fuzzy_types/fuzzy.py
@@ -56,7 +56,24 @@ class FuzzyBase(abc.ABC):
         return object.__dir__(self)
 
     @staticmethod
-    def mapper(item) -> str:
+    def mapper(item: Union[str, object]) -> str:
+        """ Mapper between list/dict item and rapidfuzz choices  
+
+        Static method used to map a list's items or dict's keys to a
+        string representation used by ``rapidfuzz`` for.  By default returns an
+        explicit string case of the item.  To see the output, view the ``choices``
+        property.  Can be overridden to customize what is input into ``rapidfuzz``. 
+
+        Parameters
+        ----------
+        item : Union[str, object]
+            Any iterable item, i.e. a list item or dictionary key
+
+        Returns
+        -------
+        str
+            The string representation to use in the choices supplied to ``rapidfuzz``
+        """
         return str(item)
 
     @abc.abstractproperty
@@ -117,6 +134,18 @@ class FuzzyBaseDict(FuzzyBase):
 
     @property
     def choices(self) -> list:
+        """ A list of choices used during fuzzy matching
+
+        The list of choices passes into ``rapidfuzz`` to use 
+        for fuzzy-matching a string.  The list of choices is computed
+        by iterating over the dictionary keys, passing each item through
+        the `~FuzzyBase.mapper` method. 
+
+        Returns
+        -------
+        list
+            The list of options used by ``rapidfuzz`` when fuzzy matching
+        """
         return [self.mapper(i) for i in self.keys()]
 
 
@@ -183,6 +212,18 @@ class FuzzyList(FuzzyBase, list):
 
     @property
     def choices(self) -> list:
+        """ A list of choices used during fuzzy matching
+
+        The list of choices passes into ``rapidfuzz`` to use 
+        for fuzzy-matching a string.  The list of choices is computed
+        by iterating over the list items, passing each item through
+        the `~FuzzyBase.mapper` method. 
+
+        Returns
+        -------
+        list
+            The list of options used by ``rapidfuzz`` when fuzzy matching
+        """
         return [self.mapper(item) for item in self]
 
     def __getitem__(self, value):

--- a/fuzzy_types/utils.py
+++ b/fuzzy_types/utils.py
@@ -16,22 +16,35 @@ import six
 from rapidfuzz import fuzz as fuzz_fuzz
 from rapidfuzz import process as fuzz_proc
 from fuzzy_types import config
+from typing import Callable, Union
 
 
-def get_best_fuzzy(value, choices, min_score=None, scorer=fuzz_fuzz.WRatio, return_score=False):
-    """ Returns the best match in a list of choices using fuzzywuzzy.
+def get_best_fuzzy(value: str, choices: list, min_score: int = None, 
+                   scorer: Callable = fuzz_fuzz.WRatio, return_score: bool = False) -> Union[None, str]:
+    """ Returns the best match in a list of choices using rapidfuzz.
 
-    Parameters:
-        value (str):
-            A string to match on
-        choices (list):
-            A list of string choices to match from
-        min_score (int):
-            The score cutoff threshold. The minimum score to consider when matching.
-        scorer (fuzzywuzzy.Ratio):
-            The fuzzywuzzy score ratio to use.  Default is WRatio.
-        return_score (bool):
-            If True, also returns the score value of the match
+    Parameters
+    ----------
+    value : str
+        A string to match on
+    choices : list
+        A list of string choices to match from
+    min_score : int
+        The score cutoff threshold. The minimum score to consider when matching. By default, None
+    scorer : Callable
+        The rapidfuzz score ratio to use.  By default, WRatio.
+    return_score : bool
+        If True, also returns the score value of the match.  By default, False.
+        
+    Returns
+    -------
+    Union[None, str]
+        Either None if no matches found above score, or the best match from list of choices 
+          
+    Raises
+    ------
+    ValueError
+        when rapidfuzz cannot find a single best match
     """
 
     assert isinstance(value, six.string_types), 'Invalid value. Must be a string.'

--- a/tests/test_fuzzydict.py
+++ b/tests/test_fuzzydict.py
@@ -72,7 +72,13 @@ class TestDict(object):
         kopy = dd.copy()
         assert isinstance(kopy, kls)
         
-        
+    def test_fuzzy_mix(self):
+        fd = FuzzyDict({1:2, 'adfdf':5, 'stuff':'hello'})
+        assert fd[1] == 2
+        assert fd['afd'] == 5
+        assert fd['stu'] == 'hello'
+        assert fd['stuff'] == 'hello'
+                
 class TestDictFails(object):
     
     @pytest.mark.parametrize('key', [('mandarin'), ('appl')], ids=['nokey', 'fuzzykey'])

--- a/tests/test_fuzzylist.py
+++ b/tests/test_fuzzylist.py
@@ -19,6 +19,24 @@ from fuzzy_types.fuzzy import FuzzyList
 real = ['apple', 'banana', 'orange', 'pear']
 fuzzy = FuzzyList(real)
 
+class Toy(object):
+    """ class representing toy objects """
+    def __init__(self, name='toy'):
+        self.name = name
+        
+    def __repr__(self):
+        return f'<Toy({self.name})>'
+
+# create a fake list of toy objects
+toys = [Toy(n) for n in ['car', 'truck', 'top', 'ball', 'rag', 'doll']]
+
+
+class FuzzyToy(FuzzyList):
+    """ custom fuzzy toy class with overridden mapper method """    
+    @staticmethod
+    def mapper(item):
+        return str(item.name)
+
 
 def assert_exact(dd):
     assert 'apple' in dd
@@ -63,8 +81,22 @@ class TestList(object):
     def test_tooriginal(self):
         orig = fuzzy.to_original()
         assert isinstance(orig, list)
+        
+    def test_fuzzy_object_default_mapper(self):
+        fd = FuzzyList(toys)
+        assert 'car' in fd
+        assert 'car' not in fd.choices
+        assert fd[3] == toys[3]
+        assert fd.choices[0] == '<Toy(car)>'
 
-
+    def test_fuzzy_object_custom_mapper(self):
+        fd = FuzzyToy(toys)
+        assert 'car' in fd
+        assert 'car' in fd.choices
+        assert fd['car'] == toys[0]
+        assert fd[3] == toys[3]
+        assert fd.choices[0] == 'car'
+        assert fd['raagg'] == toys[4]
 class TestListFails(object):
 
     @pytest.mark.parametrize('item', [('mandarin'), ('apple')], ids=['noitem', 'fuzzyitem'])


### PR DESCRIPTION
This PR closes #3.  It loosens the type restrictions on the ``choices`` iterable.  This allows for the easier creation of fuzzy lists of objects, by allowing the override of the ``mapper`` static method.  E.g. for a given class representing a Toy
```
class Toy(object):
    """ class representing toy objects """
    def __init__(self, name='toy'):
        self.name = name

    def __repr__(self):
        return f'<Toy(name="{self.name}")>'

toys = [Toy(n) for n in ['car', 'truck', 'top', 'ball', 'rag', 'doll']]
```
and we want to create new fuzzy list matching on the toy's name instead of the entire class `repr`, we can now do
```
class FuzzyToy(FuzzyList):
    """ custom fuzzy list for toys """

    @staticmethod
    def mapper(item):
        """ overridden mapper to return the toy's name """
        return str(item.name)

tt = FuzzyToy(toys)
tt
[<Toy(name="car")>, <Toy(name="truck")>, <Toy(name="top")>, <Toy(name="ball")>, <Toy(name="rag")>, <Toy(name="doll")>]

tt.choices
['car', 'truck', 'top', 'ball', 'rag', 'doll']

tt['dll']
<Toy(name="doll")>

tt.doll
<Toy(name="doll")>
```
